### PR TITLE
Power Supply Update

### DIFF
--- a/Arduino/McLighting/McLighting.ino
+++ b/Arduino/McLighting/McLighting.ino
@@ -781,13 +781,13 @@ void loop() {
       if (prevmode != mode) { snprintf(mqtt_buf, sizeof(mqtt_buf), "OK =off", ""); }
     #endif
     #if defined(POWER_SUPPLY)
-      if (prevmode != mode) {digitalWrite(POWER_SUPPLY, LOW); } // power off -> external power supply
+      if (prevmode != mode) {digitalWrite(POWER_SUPPLY, !POWER_ON); } // power off -> external power supply
     #endif
   }
   
 #if defined(POWER_SUPPLY)
   if (mode != OFF) {
-    if (prevmode != mode) {digitalWrite(POWER_SUPPLY, HIGH); } // power on -> external power supply
+    if (prevmode != mode) {digitalWrite(POWER_SUPPLY, POWER_ON); } // power on -> external power supply
   }
 #endif
 

--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -13,6 +13,9 @@
 //#define LED_TYPE_WS2811    // Uncomment, if LED type uses 400 KHz (classic 'v1' (not v2) FLORA pixels, WS2811 drivers)
 #define LED_BUILTIN 2      // ESP-12F has the built in LED on GPIO2, see https://github.com/esp8266/Arduino/issues/2192
 #define POWER_SUPPLY 12    // PIN (12 / D6) If defined, enable output to control external power supply 
+#if defined(POWER_SUPPLY)
+  #define POWER_ON   HIGH           // Define the output state to turn on the power supply, either HIGH or LOW.  Opposite will be uses for power off.
+#endif 
 
 char HOSTNAME[65] = "McLightingRGBW"; // Friedly hostname  is configurable just for the start. Hostname should not contain spaces as this can break Home Assistant discovery if used.
 


### PR DESCRIPTION
Moved the pin setting for POWER_SUPPLY to definitions.h instead of the main sketch.

I have several setups and I have some relays that are high triggers and some that are low.  This makes it much easier than trying to hunt for it in the main sketch every time.  Figured I would pass it on.  Feel free to not use it if you don't think it would be helpful.  Thank you for everything that you do on this project!!!  