### PR TITLE
fix #if block missing the last line

### DIFF
--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -521,8 +521,8 @@ void handleSetNamedMode(uint8_t * mypayload) {
       ws2812fx_mode = FX_MODE_THEATER_CHASE_RAINBOW;
       mode = SET_MODE;
     }
-#endif
 }
+#endif
 
 void handleSetWS2812FXMode(uint8_t * mypayload) {
   if (isDigit(mypayload[1])) {


### PR DESCRIPTION
Causes compiling error when ENABLE_LEGACY_ANIMATIONS is not enabled.